### PR TITLE
Add Superset integration CI job

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -53,3 +53,56 @@ jobs:
 
     - name: Run tests
       run: uv run pytest
+
+  superset-integration:
+    runs-on: ubuntu-latest
+
+    env:
+      SUPERSET_CONFIG: tests.integration_tests.superset_test_config
+      SUPERSET_TESTENV: "true"
+
+    steps:
+    - name: Checkout package
+      uses: actions/checkout@v4
+      with:
+        path: python-datastore-sqlalchemy
+
+    - name: Checkout Superset
+      uses: actions/checkout@v4
+      with:
+        repository: apache/superset
+        ref: master
+        path: superset
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Install Superset system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
+
+    - name: Install Superset dependencies
+      working-directory: superset
+      run: |
+        uv venv .venv --python 3.11
+        uv pip install -r requirements/development.txt
+        uv pip install -e ../python-datastore-sqlalchemy
+
+    - name: Initialize Superset test database
+      working-directory: superset
+      run: |
+        .venv/bin/superset db upgrade
+        .venv/bin/superset init
+        .venv/bin/superset load-test-users
+
+    - name: Run Superset datastore integration tests
+      working-directory: superset
+      run: .venv/bin/pytest -vv tests/integration_tests/db_engine_specs/datastore_tests.py


### PR DESCRIPTION
## Summary

- Add a dedicated Superset integration job to the Python CI workflow.
- Check out apache/superset master and run Superset's Datastore DB engine spec tests against the local package checkout.
- Use Python 3.11 for the Superset job to match current Superset support.
- Install Superset system dependencies required by native development dependencies such as python-ldap.

## Test scope

This PR intentionally runs the targeted Superset Datastore integration tests instead of the full Superset test suite on every package change. The full upstream suite is broad, slow, and can fail for unrelated frontend, service, database, or environment reasons. The targeted Datastore engine tests provide the relevant blocking signal for python-datastore-sqlalchemy compatibility.

## Validation

- GitHub Actions Python CI passed on branch superset-integration-test, run 31508057525.
- build job passed.
- superset-integration job passed.