### PR TITLE
Address SQLAlchemy and Datastore warning coverage

### DIFF
--- a/sqlalchemy_datastore/base.py
+++ b/sqlalchemy_datastore/base.py
@@ -20,6 +20,7 @@ import logging
 from typing import Any, List, Optional
 
 from google.cloud import firestore_admin_v1
+from google.cloud.datastore.query import PropertyFilter
 from google.oauth2 import service_account
 from sqlalchemy import exc
 from sqlalchemy.engine import Connection, default
@@ -54,6 +55,7 @@ class CloudDatastoreDialect(default.DefaultDialect):
     supports_unicode_binds = True
     returns_unicode_strings = True
     description_encoding = None
+    supports_statement_cache = False
 
     # JSON support - required for SQLAlchemy JSON type
     _json_serializer = None
@@ -88,9 +90,14 @@ class CloudDatastoreDialect(default.DefaultDialect):
         self._client = None
 
     @classmethod
-    def dbapi(cls):
+    def import_dbapi(cls):
         """Return the DBAPI 2.0 driver."""
         return datastore_dbapi
+
+    @classmethod
+    def dbapi(cls):
+        """Return the DBAPI 2.0 driver."""
+        return cls.import_dbapi()
 
     def do_ping(self, dbapi_connection):
         """Performs a simple operation to check if the connection is still alive."""
@@ -212,7 +219,7 @@ class CloudDatastoreDialect(default.DefaultDialect):
         """Retrieve column information from the database."""
         client = self._client
         query = client.query(kind="__Stat_PropertyType_PropertyName_Kind__")
-        query.add_filter("kind_name", "=", table_name)
+        query.add_filter(filter=PropertyFilter("kind_name", "=", table_name))
         properties = list(query.fetch())
 
         return [

--- a/tests/test_integration_queries.py
+++ b/tests/test_integration_queries.py
@@ -33,8 +33,10 @@ def test_update_user(conn, datastore_client):
 
     # Find the inserted entity by querying the datastore client directly
     query = datastore_client.query(kind="users")
-    query.add_filter("name", "=", "UpdateTestUser")
-    entities = list(query.fetch())
+    entities = [
+        entity for entity in query.fetch()
+        if entity.get("name") == "UpdateTestUser"
+    ]
     assert len(entities) >= 1
     entity_id = entities[0].key.id
 
@@ -62,8 +64,10 @@ def test_delete_user(conn, datastore_client):
 
     # Find the inserted entity
     query = datastore_client.query(kind="users")
-    query.add_filter("name", "=", "DeleteTestUser")
-    entities = list(query.fetch())
+    entities = [
+        entity for entity in query.fetch()
+        if entity.get("name") == "DeleteTestUser"
+    ]
     assert len(entities) >= 1
     entity_id = entities[0].key.id
 
@@ -332,8 +336,10 @@ def test_task_insert_update_delete_raw_sql(conn, datastore_client):
 
     # Find the inserted entity
     query = datastore_client.query(kind="tasks")
-    query.add_filter("task", "=", "Coverage Test Task")
-    entities = list(query.fetch())
+    entities = [
+        entity for entity in query.fetch()
+        if entity.get("task") == "Coverage Test Task"
+    ]
     assert len(entities) >= 1
     entity_id = entities[0].key.id
 

--- a/tests/test_unit_types.py
+++ b/tests/test_unit_types.py
@@ -17,6 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """Unit tests for _types module (no emulator required)."""
+import pytest
 import sqlalchemy.types
 from google.cloud.bigquery.schema import SchemaField
 
@@ -190,7 +191,13 @@ def test_get_sqla_column_type_repeated():
 
 def test_get_sqla_column_type_unknown():
     field = SchemaField("mystery", "UNKNOWN_TYPE_XYZ")
-    coltype = _get_sqla_column_type(field)
+
+    with pytest.warns(
+        sqlalchemy.exc.SAWarning,
+        match="Did not recognize type 'UNKNOWN_TYPE_XYZ' of column 'mystery'",
+    ):
+        coltype = _get_sqla_column_type(field)
+
     assert coltype is sqlalchemy.types.NullType
 
 


### PR DESCRIPTION
## Summary

- Update the dialect for newer SQLAlchemy and Google Datastore client warning paths.
- Add SQLAlchemy 2 style import_dbapi while keeping dbapi as a compatibility wrapper.
- Disable SQLAlchemy statement cache support explicitly for this dialect.
- Use Datastore PropertyFilter where production code builds filters.
- Avoid deprecated positional add_filter calls in integration tests that only need to locate inserted emulator entities.
- Improve the unknown BigQuery type test so UNKNOWN_TYPE_XYZ is expected to emit SAWarning and still fallback to NullType.

## Python version decision

This PR does not change requires-python. Latest google-cloud-datastore 2.26.0 still declares Python >=3.10 support, so raising this project to Python >=3.11 is a separate support-policy change. I will handle that work on a dedicated branch.

## Validation

- GCLOUD_PATH=/mnt/workspace/code/google-cloud-sdk/bin/gcloud uv run pytest
- Result: 399 passed, 2 warnings

The remaining warnings are Google client library Python 3.10 EOL notices, not the UNKNOWN_TYPE_XYZ warning covered by this PR.